### PR TITLE
Improve the Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,30 @@
 language: php
+
 php:
     - 5.3
     - 5.4
     - 5.5
+    - 5.6
+    - hhvm
+    - nightly
 
-before_script: composer install --dev
+matrix:
+    include:
+        - php: 5.3
+          env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
+    allow_failures:
+        - php: hhvm
+        - php: nightly
 
-script: phpunit --coverage-text
+sudo: false
+
+cache:
+    directories:
+        - $HOME/.composer/cache
+
+install: composer update -n $COMPOSER_FLAGS
+
+script: phpunit --coverage-clover=coverage.clover
+
+after_script:
+    - wget https://scrutinizer-ci.com/ocular.phar && php ocular.phar code-coverage:upload --format=php-clover coverage.clover

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=5.3.2",
         "symfony/framework-bundle": "~2.3",
-        "symfony/console": "~2.0",
+        "symfony/console": "~2.3",
         "symfony/translation": "~2.3"
     },
     "require-dev": {


### PR DESCRIPTION
- Test on PHP 5.6, PHP 7 and HHVM
- use the faster docker-based infrastructure
- keep the composer cache between builds
- test on lowest version of dependencies
- upload the code coverage to scrutinizer